### PR TITLE
Migrating from master and slave vocabulary

### DIFF
--- a/vultr.py
+++ b/vultr.py
@@ -32,7 +32,7 @@ logf_name = 'vultr.log' # vultr log file name
 CHECK_INTERVAL_MAX = 10 # maximum check interval (minutes)
 CHECK_INTERVAL_MIN = 4 # # minimum check interval (minutes)
 check_int = CHECK_INTERVAL_MAX
-CHECK_PORT = '1010' # slave's port which master will use tcpping to check, make sure this port is open on slave server!
+CHECK_PORT = '1010' # subordinate's port which main will use tcpping to check, make sure this port is open on subordinate server!
 RANDOM_REGION = True # True: randomly select new region from REGION_LIST when detected a blocked server; False: keep the same region as the old server
 REGION_LIST = ['Atlanta', 'Dallas', 'Chicago', 'Los Angeles', 'Silicon Valley', 'Seattle', 'Miami'] # regions that can be randomly selected for new server
 '''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.